### PR TITLE
Feat[login]: 로그인 실패시 에러메세지 띄워주는 기능추가

### DIFF
--- a/src/components/domain/auth/Login.tsx
+++ b/src/components/domain/auth/Login.tsx
@@ -31,12 +31,18 @@ const Login = () => {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const responseItem = await login(userInputId, userInputPassword);
-    if (responseItem._id !== -1) {
+    const errorMessage = responseItem.message;
+    // response 된 data 에 _id 라는 key 가 있다면 로그인 성공으로 간주합니다.
+    if ("_id" in responseItem) {
       setIsToastOpen(true);
       setAlertText("로그인이 완료되었습니다");
       setBgColor("var(--toast-success)");
       updateUserBasicInfo(responseItem.token, responseItem);
       navigate("/home");
+    } else {
+      setIsToastOpen(true);
+      setAlertText(errorMessage);
+      setBgColor("var(--toast-error)");
     }
   };
 

--- a/src/store/authSlice.tsx
+++ b/src/store/authSlice.tsx
@@ -16,7 +16,7 @@ const requestSignUp: (arg: Person) => Promise<AuthAlertType> = async (
       AuthResponseType
     >(`${BASE_URL}/users/`, UserInput);
     if (response.data.ok === 1) {
-      return {ok: true, message: "회원가입이 완료되었습니다"};
+      return { ok: true, message: "회원가입이 완료되었습니다" };
     }
   } catch (error: unknown) {
     if (axios.isAxiosError(error)) {
@@ -24,40 +24,41 @@ const requestSignUp: (arg: Person) => Promise<AuthAlertType> = async (
         const errorMessage: string = error.response.data.errors[0]?.msg
           ? error.response.data.errors[0].msg
           : error.response.data.message;
-        return {ok: false, message: errorMessage}
+        return { ok: false, message: errorMessage };
       }
     }
     console.error("Error:", error);
-    return {ok: false, message: "unknown error"};
+    return { ok: false, message: "unknown error" };
   }
-  return {ok: false, message: "unknown error"};
+  return { ok: false, message: "unknown error" };
 };
 
 //이메일 중복확인 요청
-const requestEmailVerification: (arg: string) => Promise<AuthAlertType> = async (
-  email: string
-) => {
+const requestEmailVerification: (
+  arg: string
+) => Promise<AuthAlertType> = async (email: string) => {
   try {
     const response = await axios.get<string, AuthResponseType>(
       `${BASE_URL}/users/email?email=${email}`
     );
-    console.log(response)
-    console.log(response.data)
+    console.log(response);
+    console.log(response.data);
     if (response.data.ok === 1) {
-      return {ok: true, message: "이메일 인증이 완료되었습니다"};
+      return { ok: true, message: "이메일 인증이 완료되었습니다" };
     }
   } catch (error: unknown) {
-    console.log(error)
-    if (!axios.isAxiosError(error)) return {ok: false, message: "unknown error"};
+    console.log(error);
+    if (!axios.isAxiosError(error))
+      return { ok: false, message: "unknown error" };
     if (error.response) {
       const errorMessage: string = error.response.data.errors
         ? error.response.data.errors[0].msg
         : error.response.data.message;
-      return {ok: false, message: errorMessage}
+      return { ok: false, message: errorMessage };
     }
-  return {ok: false, message: "unknown error"}
+    return { ok: false, message: "unknown error" };
   }
-  return {ok: false, message: "unknown error"}
+  return { ok: false, message: "unknown error" };
 };
 
 //로그인 후 토큰 받아오는 함수
@@ -77,13 +78,11 @@ const requestUserLogin = async (email: string, password: string) => {
     // response 객체 안에 item return
     return response.data.item;
   } catch (error: unknown) {
-    if (axios.isAxiosError(error))
-      if (error.response) {
-        const errorMessage: string = error.response.data.errors[0]?.msg
-          ? error.response.data.errors[0].msg
-          : error.response.data.message;
-        alert(errorMessage);
-      }
+    if (axios.isAxiosError(error)) {
+      //axios 에러시 에러 메세지를 담은 data를 return 합니다.
+      console.error(error.response?.data);
+      return error.response?.data;
+    }
     console.error("로그인이 실패하였습니다.");
   }
   return {

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -17,7 +17,7 @@ type ExtraType = {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 interface AuthSlice {
-  userToken: TokenInfoType['token'];
+  userToken: TokenInfoType["token"];
   userBasicInfo: UserBasicInfoType;
   isLoggedIn: boolean;
   signUp: (UserInput: UserInputType) => Promise<AuthAlertType>;
@@ -25,9 +25,9 @@ interface AuthSlice {
   login: (
     email: string,
     password: string
-  ) => Promise<UserBasicInfoType & TokenInfoType>;
+  ) => Promise<UserBasicInfoType & TokenInfoType & LoginDataError>;
   updateUserBasicInfo: (
-    userToken: TokenInfoType['token'],
+    userToken: TokenInfoType["token"],
     userBasicInfo: UserBasicInfoType
   ) => void;
   logout: () => void;
@@ -52,10 +52,16 @@ interface UserBasicInfoType {
 }
 
 interface TokenInfoType {
-  token : {
-  accessToken: string;
-  refreshToken: string;
-}}
+  token: {
+    accessToken: string;
+    refreshToken: string;
+  };
+}
+
+interface LoginDataError {
+  ok: number;
+  message: string;
+}
 
 interface LoginResponseType {
   config: object;
@@ -66,6 +72,6 @@ interface LoginResponseType {
 }
 
 interface AuthAlertType {
-  ok: boolean,
-  message: string
+  ok: boolean;
+  message: string;
 }


### PR DESCRIPTION
이전 코드엔 로그인 실패시 왜 실패했는지 나오지 않고 콘솔 에러만 띄워졌지만
로그인 실패시 에러메세지를 띄워줄 수 있도록 처리하였습니다.

![image](https://github.com/suconpa/my-parking-app/assets/89624140/8ce40ac4-726f-45bd-9725-aa8d9e60d51d)



해당 함수를 받는 컴포넌트에선 아래와 같이 처리하였습니다.
![image](https://github.com/suconpa/my-parking-app/assets/89624140/b88ff9af-6e7e-4dee-9445-7e960bd9985e)
