### PR TITLE
Feat: 결제하기 버튼 눌렀을 때 결제 기능 추가하기

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
       type="text/javascript"
       src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_API_KEY%&libraries=services,clusterer,drawing"
     ></script>
+    <!-- 결제 시스템 script jQuery Start-->
     <script
       type="text/javascript"
       src="https://code.jquery.com/jquery-1.12.4.min.js"
@@ -16,13 +17,11 @@
       type="text/javascript"
       src="https://cdn.iamport.kr/js/iamport.payment-1.1.8.js"
     ></script>
-
+    <!-- 결제 시스템 script jQuery End -->
     <title>MY PARKING</title>
   </head>
   <body>
     <div id="root"></div>
-    <!-- 결제 시스템 script -->
-    <!-- jQuery -->
 
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -8,11 +8,22 @@
       type="text/javascript"
       src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_API_KEY%&libraries=services,clusterer,drawing"
     ></script>
+    <script
+      type="text/javascript"
+      src="https://code.jquery.com/jquery-1.12.4.min.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="https://cdn.iamport.kr/js/iamport.payment-1.1.8.js"
+    ></script>
 
     <title>MY PARKING</title>
   </head>
   <body>
     <div id="root"></div>
+    <!-- 결제 시스템 script -->
+    <!-- jQuery -->
+
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/domain/purchase/PaymentMethod.tsx
+++ b/src/components/domain/purchase/PaymentMethod.tsx
@@ -1,9 +1,108 @@
-// 결제 수단 컴포넌트
-// import axios from "axios";
-// import React from "react";
+import { useNavigate } from "react-router-dom";
+import { CommonButtonSmall } from "../../UI/CommonButton";
+import { useBoundStore } from "../../../store";
+import useCustomAxios from "../../../services/useCustomAxios";
 
-const PaymentMethod = () => {
-  return <div></div>;
+declare global {
+  interface Window {
+    IMP: {
+      init: (s: string) => void;
+      request_pay: (
+        data: PaymentData,
+        callback: (res: PaymentResDataType) => void
+      ) => void;
+    };
+  }
+}
+
+interface PaymentMethodProps {
+  disabled: boolean;
+  paymentOption: string;
+}
+
+const PaymentMethod = ({ disabled, paymentOption }: PaymentMethodProps) => {
+  const navigate = useNavigate();
+  const axiosInstance = useCustomAxios();
+  const userBasicInfo = useBoundStore((state) => state.userBasicInfo);
+  const productDetailData = useBoundStore((state) => state.productDetailData);
+
+  console.log(productDetailData);
+
+  function onClickPayment() {
+    /* 1. 가맹점 식별하기 */
+    const { IMP } = window;
+    IMP.init("imp14397622");
+
+    /* 2. 결제 데이터 정의하기 */
+    const data = {
+      pg: "html5_inicis", // PG사
+      pay_method: paymentOption, // 결제수단
+      merchant_uid: `mid_${new Date().getTime()}`, // 주문번호
+      // amount: productDetailData.price, // 결제금액
+      amount: 1, // 결제금액
+      name: productDetailData.name, // 주문상품명
+      buyer_name: userBasicInfo.name, // 구매자 이름
+      buyer_tel: userBasicInfo.phone, // 구매자 전화번호
+      buyer_email: userBasicInfo.email, // 구매자 이메일
+      buyer_addr: userBasicInfo.address, // 구매자 주소
+    };
+
+    /* 4. 결제 창 호출하기 */
+    IMP.request_pay(data, purchaseResult);
+  }
+
+  /* 3. 콜백 함수 정의하기 */
+  function purchaseResult(response: PaymentResDataType) {
+    const { success, error_msg } = response;
+    // console.log(response);
+    if (success) {
+      alert("결제 성공");
+      // 실제 결제 성공 후 db에 결제 정보 저장이 됩니다.
+      // 오늘 날짜 받아오는 함수
+      const nowDate = () => {
+        const year = new Date().getFullYear();
+        const month = new Date().getMonth() + 1;
+        const day = new Date().getDate();
+        return `${year}.${month}.${day}`;
+      };
+
+      const postData = async () => {
+        const body = {
+          products: [
+            {
+              _id: productDetailData._id,
+              quantity: productDetailData.quantity,
+            },
+          ],
+          address: {
+            name: userBasicInfo.address,
+            value: productDetailData.name,
+          },
+          extra: {
+            buyDate: nowDate(),
+          },
+        };
+
+        try {
+          await axiosInstance.post("/orders", body);
+          navigate("/purchase/result");
+        } catch (error) {
+          console.error("결제 에러");
+        }
+      };
+      postData();
+      navigate("/purchase/result");
+    } else {
+      alert(`결제 실패: ${error_msg}`);
+    }
+  }
+  return (
+    <CommonButtonSmall
+      disabled={disabled}
+      text="결제하기"
+      onClick={onClickPayment}
+    />
+  );
 };
 
 export default PaymentMethod;

--- a/src/components/domain/purchase/Purchase.tsx
+++ b/src/components/domain/purchase/Purchase.tsx
@@ -8,34 +8,18 @@ import { BASE_URL } from "../../../services/BaseUrl";
 import classes from "./purchase.module.css";
 import MediaQuery from "../../UI/MediaQuery";
 import { Toast } from "../../UI/Toast";
+import PaymentMethod from "./PaymentMethod";
 
 const Purchase = () => {
   const navigate = useNavigate();
   const isMobile = MediaQuery();
   const productDetailData = useBoundStore((state) => state.productDetailData);
-
-  const axiosInstance = useCustomAxios();
-  const userBasicInfo = useBoundStore((state) => state.userBasicInfo);
   const [checked, setChecked] = useState({ name: "", value: false });
 
-  const setIsToastOpen = useBoundStore((state) => state.setIsToastOpen);
-  const setAlertText = useBoundStore((state) => state.setAlertText);
-  const setBgColor = useBoundStore((state) => state.setBgColor);
+
   const isToastOpen = useBoundStore((state) => state.isToastOpen);
   const alertText = useBoundStore((state) => state.alertText);
   const bgColor = useBoundStore((state) => state.bgColor);
-
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    // 결제수단을 입력하지 않을 시 경고 창
-    if (!checked.value) {
-      setIsToastOpen(true);
-      setAlertText("결제수단을 입력해주세요");
-      setBgColor("var(--toast-error)");
-    } else if (checked.value) {
-      postData();
-    }
-  };
 
   const handleOnChange = (
     e:
@@ -51,39 +35,6 @@ const Purchase = () => {
       name: selectedValue,
       value: true,
     }));
-  };
-
-  // 오늘 날짜 받아오는 함수
-  const nowDate = () => {
-    const year = new Date().getFullYear();
-    const month = new Date().getMonth() + 1;
-    const day = new Date().getDate();
-    return `${year}.${month}.${day}`;
-  };
-
-  const postData = async () => {
-    const body = {
-      products: [
-        {
-          _id: productDetailData._id,
-          quantity: productDetailData.quantity,
-        },
-      ],
-      address: {
-        name: userBasicInfo.address,
-        value: productDetailData.name,
-      },
-      extra: {
-        buyDate: nowDate(),
-      },
-    };
-
-    try {
-      await axiosInstance.post("/orders", body);
-      navigate("/purchase/result");
-    } catch (error) {
-      console.error("결제 에러");
-    }
   };
 
   return (
@@ -107,11 +58,9 @@ const Purchase = () => {
         endDate={productDetailData.extra.endDate}
         sellerId={productDetailData.seller_id}
       />
-      <PurchaseForm
-        onSubmit={handleSubmit}
-        onChange={handleOnChange}
-        total={productDetailData.price}
-      />
+      <PurchaseForm onChange={handleOnChange} total={productDetailData.price} />
+      {/* paymentOption 에 따라 결제 방식이 달라집니다. */}
+      <PaymentMethod disabled={!checked.value} paymentOption={checked.name} />
       <Toast
         isToastOpen={isToastOpen}
         alertText={alertText}

--- a/src/components/domain/purchase/PurchaseForm.tsx
+++ b/src/components/domain/purchase/PurchaseForm.tsx
@@ -7,12 +7,12 @@ import {
   RadioGroup,
   Typography,
 } from "@mui/material";
-import { CommonButtonMiddle } from "../../UI/CommonButton";
+import { CommonButtonMiddle, CommonButtonSmall } from "../../UI/CommonButton";
 import PurchaseInformation from "./PurchaseInformation";
 import classes from "./purchase.module.css";
 
 interface PurchaseFormProps {
-  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onSubmit?: (e: React.FormEvent<HTMLFormElement>) => void;
   onChange: (e: React.SyntheticEvent<Element, Event>) => void;
   total: number;
 }
@@ -45,7 +45,7 @@ const PurchaseForm: React.FC<PurchaseFormProps> = ({
                 onChange={onChange}
               />
               <FormControlLabel
-                value="noPassBook"
+                value="vbank"
                 control={<Radio />}
                 label="무통장입금"
                 onChange={onChange}
@@ -78,7 +78,6 @@ const PurchaseForm: React.FC<PurchaseFormProps> = ({
             >
               총 {total} 원
             </Typography>
-            <CommonButtonMiddle text="결제" />
           </Box>
         </form>
       </Box>

--- a/src/types/purchase.d.ts
+++ b/src/types/purchase.d.ts
@@ -2,3 +2,46 @@ interface PurchaseSlice {
   productDetailData: productDetailDataType;
   setProductDetailData: (data: productDetailDataType) => void;
 }
+
+interface PaymentData {
+  pg: string; // PG사
+  pay_method: string; // 결제수단
+  merchant_uid: string; // 주문번호
+  amount: number; // 결제금액
+  name: string; // 주문명
+  buyer_name: string; // 구매자 이름
+  buyer_tel: string; // 구매자 전화번호
+  buyer_email: string; // 구매자 이메일
+  buyer_addr: string; // 구매자 주소
+}
+
+interface PaymentResDataType {
+  //안쓰는 타입 수정예정
+  apply_num: string;
+  bank_name: null | string;
+  buyer_addr: string;
+  buyer_email: string;
+  buyer_name: string;
+  buyer_postcode: null | string;
+  buyer_tel: string;
+  card_name: null | string;
+  card_number: string;
+  card_quota: number;
+  currency: string;
+  custom_data: null | string;
+  imp_uid: string;
+  merchant_uid: string;
+  name: string;
+  paid_amount: number;
+  paid_at: number;
+  pay_method: string;
+  pg_provider: string;
+  pg_tid: string;
+  pg_type: string;
+  receipt_url: string;
+  status: string;
+  success: boolean;
+  error_msg: string;
+}
+
+// 예시로 사용한 타입은 필요에 따라 수정 가능합니다.


### PR DESCRIPTION
## [PaymentMethod.tsx](https://github.com/suconpa/my-parking-app/pull/5/files#diff-1cfc1a4707ed2178aa86b8302c190b93788ca6a4dc79fc6a8b50208047facecf)  에 결제를 실제로 진행 할 수 있는 기능을 추가하였습니다.
_해당 기능 구현은 아래 사이트를 참고하여 개발하였습니다._
* 포트원 테스트 결제: https://sdk-playground.portone.io/
    * 포트원 결제 API(React): https://github.com/iamport/iamport-react-example
    * 샘플 앱 참고(client-app/src/pages/order/OrderNew.tsx)

1. 실제 결제가 이뤄진 후 db에 저장되게 로직을 작성하였습니다.
2. [ 코드 수정 전]엔 user가 결제하기 버튼을 눌렀을 때 결제방식이 선택되었는지 확인 후 선택되지 않았다면 toastUI 를 띄웠는데 [ 코드 수정 후 ] user가 결제 방식을 선택하지 않으면 아예 버튼이 활성화 되지않게 처리했기 때문에 form 태그에 있는 onSubmit 이벤트를 삭제하였습니다.
3. user가 선택한 결제 방식에 따라 실제 결제되는 방식이 달라집니다.

[issue]
해당 API 의 success response 의 타입을 지정 할 때 어떤 값이 필요할 지 몰라 일단 return 되는 data의 타입을 모두 명시해놓았습니다.
[src/types/purchase.d.ts](https://github.com/suconpa/my-parking-app/pull/5/files#diff-19f0b351bff0684d2111d0b4fcf02fb5cdb51cf98825d13914f5d8260a6b047c)